### PR TITLE
feat: user controller init

### DIFF
--- a/lib/edgehog_device_forwarder_web/body_parser.ex
+++ b/lib/edgehog_device_forwarder_web/body_parser.ex
@@ -1,0 +1,31 @@
+# Copyright 2024 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderWeb.BodyParser do
+  @moduledoc """
+  Body parser which just copies the content inside body_params.
+  """
+
+  @behaviour Plug
+
+  def init(opts) do
+    Keyword.pop(opts, :body_reader, {Plug.Conn, :read_body, []})
+  end
+
+  def call(conn, {{mod, fun, args}, opts}) do
+    case apply(mod, fun, [conn, opts | args]) do
+      {:ok, body, conn} ->
+        conn = %{conn | body_params: %{}}
+        update_in(conn.assigns, &Map.put(&1, :body, body))
+
+      {:more, _data, _conn} ->
+        raise Plug.Parsers.RequestTooLargeError
+
+      {:error, :timeout} ->
+        raise Plug.TimeoutError
+
+      {:error, _} ->
+        raise Plug.BadRequestError
+    end
+  end
+end

--- a/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
+++ b/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
@@ -1,0 +1,70 @@
+# Copyright 2024 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderWeb.UserController do
+  @moduledoc """
+  Controller for client requests.
+  """
+
+  use EdgehogDeviceForwarderWeb, :controller
+
+  alias EdgehogDeviceForwarder.Forwarder
+  alias EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http, as: HTTP
+
+  @doc """
+  Redirect the request to the appropriate device session.
+  """
+  @spec handle_in(Plug.Conn.t(), any) ::
+          Plug.Conn.t()
+          | {:error, :invalid_request_port}
+          | {:error, :request_timeout}
+          | {:error, :token_not_found}
+  def handle_in(conn, _params) do
+    token = conn.path_params["session"]
+
+    with {:ok, request} <- build_request(conn) do
+      case Forwarder.http_to_device(token, request) do
+        {:respond, response} ->
+          conn
+          |> merge_resp_headers(response.headers)
+          |> send_resp(response.status_code, response.body)
+          |> halt()
+
+        {{:upgrade, :websocket}, _response, socket_data} ->
+          raise "Method not yet supported. Socket data: #{inspect(socket_data)}"
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @spec build_request(Plug.Conn.t()) :: {:ok, HTTP.Request.t()} | {:error, :invalid_request_port}
+  defp build_request(conn) do
+    with {:ok, port} <- fetch_port(conn) do
+      request = %HTTP.Request{
+        path: Enum.join(conn.path_params["path"], "/"),
+        method: conn.method,
+        query_string: conn.query_string,
+        headers: Map.new(conn.req_headers),
+        body: conn.assigns.body,
+        port: port
+      }
+
+      {:ok, request}
+    end
+  end
+
+  @spec fetch_port(Plug.Conn.t()) :: {:ok, integer()} | {:error, :invalid_request_port}
+  defp fetch_port(conn) do
+    with {port, ""} <- Integer.parse(conn.path_params["port"]),
+         true <- valid_port_range?(port) do
+      {:ok, port}
+    else
+      _ -> {:error, :invalid_request_port}
+    end
+  end
+
+  @spec valid_port_range?(integer) :: boolean
+  defp valid_port_range?(port), do: port <= 65535 and port > 0
+end

--- a/lib/edgehog_device_forwarder_web/endpoint.ex
+++ b/lib/edgehog_device_forwarder_web/endpoint.ex
@@ -30,10 +30,7 @@ defmodule EdgehogDeviceForwarderWeb.Endpoint do
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
-  plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
+  plug EdgehogDeviceForwarderWeb.BodyParser
 
   plug Plug.MethodOverride
   plug Plug.Head

--- a/lib/edgehog_device_forwarder_web/router.ex
+++ b/lib/edgehog_device_forwarder_web/router.ex
@@ -1,15 +1,11 @@
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule EdgehogDeviceForwarderWeb.Router do
   use EdgehogDeviceForwarderWeb, :router
 
-  pipeline :api do
-    plug :accepts, ["json"]
-  end
-
-  scope "/api", EdgehogDeviceForwarderWeb do
-    pipe_through :api
+  scope "/v1/:session/:protocol/:port", EdgehogDeviceForwarderWeb do
+    match :*, "/*path", UserController, :handle_in
   end
 
   if Application.compile_env(:edgehog_device_forwarder, :dev_routes) do

--- a/test/edgehog_device_forwarder_web/controllers/user_controller_test.exs
+++ b/test/edgehog_device_forwarder_web/controllers/user_controller_test.exs
@@ -1,0 +1,25 @@
+# Copyright 2024 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderWeb.UserControllerTest do
+  use EdgehogDeviceForwarder.ForwarderCase
+  use EdgehogDeviceForwarderWeb.ConnCase
+
+  describe "handle_in/2" do
+    test "redirects the request to the forwarder", %{
+      conn: conn,
+      ping_pong_token: token,
+      http_request: request
+    } do
+      path = "/v1/#{token}/http/80"
+
+      conn
+      |> add_request_headers(request.headers)
+      |> get(path, request.body)
+      |> response(200)
+    end
+  end
+
+  def add_header({header, value}, conn), do: Plug.Conn.put_req_header(conn, header, value)
+  def add_request_headers(conn, headers), do: Enum.reduce(headers, conn, &add_header/2)
+end


### PR DESCRIPTION
handle requests ~and return a somewhat plausible (although fake) response.~ to and from the device using the redirector.

future PRs for the controller will need to
- handle websocket upgrade
- ~remove the request id, as it should be generated from the `Connections` module~
- have a fallback controller of some sort
- ~add tests~

depends on #7 and includes its commits
closes #3