### PR TITLE
feat(monitor): init

### DIFF
--- a/lib/edgehog_device_forwarder/application.ex
+++ b/lib/edgehog_device_forwarder/application.ex
@@ -11,6 +11,7 @@ defmodule EdgehogDeviceForwarder.Application do
     children = [
       EdgehogDeviceForwarderWeb.Telemetry,
       {Phoenix.PubSub, name: EdgehogDeviceForwarder.PubSub},
+      EdgehogDeviceForwarder.Supervisors.TerminationCallbacks,
       EdgehogDeviceForwarderWeb.Endpoint
     ]
 

--- a/lib/edgehog_device_forwarder/supervisors/termination_callbacks.ex
+++ b/lib/edgehog_device_forwarder/supervisors/termination_callbacks.ex
@@ -1,0 +1,25 @@
+defmodule EdgehogDeviceForwarder.Supervisors.TerminationCallbacks do
+  use Supervisor
+
+  @table :termination_callbacks_table
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(_init_args) do
+    con_cache_child = con_cache_spec()
+    children = [con_cache_child, EdgehogDeviceForwarder.TerminationCallbacks]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  defp con_cache_spec do
+    params = [name: @table, ttl_check_interval: false]
+    id = {ConCache, @table}
+
+    {ConCache, params}
+    |> Supervisor.child_spec(id: id)
+  end
+end

--- a/lib/edgehog_device_forwarder/termination_callbacks.ex
+++ b/lib/edgehog_device_forwarder/termination_callbacks.ex
@@ -1,0 +1,51 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarder.TerminationCallbacks do
+  use GenServer
+
+  @table :termination_callbacks_table
+
+  @spec add(pid, (-> any)) :: :ok
+  def add(pid, on_close) when is_pid(pid) and is_function(on_close, 0) do
+    GenServer.cast(__MODULE__, {:add, pid, on_close})
+  end
+
+  @spec start_link(any) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    # If the server is restarted, our pid changed
+    #   hence, to receive the :DOWN, we need to re-monitor existing processes
+    #   Process.monitor also sends the :DOWN for already dead pid, so we don't need to check that.
+    ets_ref = ConCache.ets(@table)
+
+    for {pid, _} <- :ets.tab2list(ets_ref) do
+      Process.monitor(pid)
+    end
+
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def handle_cast({:add, pid, on_close}, state)
+      when is_pid(pid) and is_function(on_close, 0) do
+    Process.monitor(pid)
+    ConCache.put(@table, pid, on_close)
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    # always run the callback at least once before deleting it
+    callback = ConCache.get(@table, pid)
+    unless callback == nil, do: callback.()
+    ConCache.delete(@table, pid)
+
+    {:noreply, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule EdgehogDeviceForwarder.MixProject do
 
   defp deps do
     [
+      {:con_cache, "~> 1.0"},
       {:gettext, "~> 0.23"},
       {:jason, "~> 1.4"},
       {:phoenix, "~> 1.7"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "castore": {:hex, :castore, "1.0.4", "ff4d0fb2e6411c0479b1d965a814ea6d00e51eb2f58697446e9c41a97d940b28", [:mix], [], "hexpm", "9418c1b8144e11656f0be99943db4caf04612e3eaecefb5dae9a2a87565584f8"},
+  "con_cache": {:hex, :con_cache, "1.0.0", "6405e2bd5d5005334af72939432783562a8c35a196c2e63108fe10bb97b366e6", [:mix], [], "hexpm", "4d1f5cb1a67f3c1a468243dc98d10ac83af7f3e33b7e7c15999dc2c9bc0a551e"},
   "cowboy": {:hex, :cowboy, "2.10.0", "ff9ffeff91dae4ae270dd975642997afe2a1179d94b1887863e43f681a203e26", [:make, :rebar3], [{:cowlib, "2.12.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "3afdccb7183cc6f143cb14d3cf51fa00e53db9ec80cdcd525482f5e99bc41d6b"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.4.0", "f239f68b588efa7707abce16a84d0d2acf3a0f50571f8bb7f56a15865aae820c", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7d98bac1ee4565d31b62d59f8823dfd8356a169e7fcbb83831b8a5397404c9de"},
   "cowlib": {:hex, :cowlib, "2.12.1", "a9fa9a625f1d2025fe6b462cb865881329b5caff8f1854d1cbc9f9533f00e1e1", [:make, :rebar3], [], "hexpm", "163b73f6367a7341b33c794c4e88e7dbfe6498ac42dcd69ef44c5bc5507c8db0"},

--- a/test/edgehog_device_forwarder/termination_callbacks_test.exs
+++ b/test/edgehog_device_forwarder/termination_callbacks_test.exs
@@ -1,0 +1,55 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarder.TerminationCallbacksTest do
+  use ExUnit.Case
+
+  alias EdgehogDeviceForwarder.Supervisors.TerminationCallbacks,
+    as: TerminationCallbacksSupervisor
+
+  alias EdgehogDeviceForwarder.TerminationCallbacks
+
+  setup do
+    Supervisor.terminate_child(EdgehogDeviceForwarder.Supervisor, TerminationCallbacksSupervisor)
+    Supervisor.restart_child(EdgehogDeviceForwarder.Supervisor, TerminationCallbacksSupervisor)
+
+    process = spawn(fn -> wait_for_exit() end)
+    [process: process]
+  end
+
+  test "callback closure is executed once the process exits", %{process: process} do
+    message = :done
+    me = self()
+    send_message_to_self = fn -> send(me, message) end
+    TerminationCallbacks.add(process, send_message_to_self)
+
+    send(process, :exit)
+    assert_receive ^message
+  end
+
+  test "the callback is executed even if the server restarts", %{process: process} do
+    message = :done
+    me = self()
+    send_message_to_self = fn -> send(me, message) end
+
+    TerminationCallbacks.add(process, send_message_to_self)
+
+    # get_state always runs synchronously after `add` finishes.
+    #   we use this to make sure the callback has been inserted in the cache
+    #   before killing the process
+    GenServer.whereis(TerminationCallbacks)
+    |> :sys.get_state()
+
+    Supervisor.terminate_child(TerminationCallbacksSupervisor, TerminationCallbacks)
+    Supervisor.restart_child(TerminationCallbacksSupervisor, TerminationCallbacks)
+
+    send(process, :exit)
+    assert_receive ^message, :timer.seconds(1)
+  end
+
+  def wait_for_exit do
+    receive do
+      :exit -> :ok
+    end
+  end
+end


### PR DESCRIPTION
initialize process monitoring, by calling ~`Monitor.monitor`~ `TerminationCallbacks.add` with a pid and a callback

depends on #17 and includes its commits