### PR TITLE
feat(user_controller): init fallback controller

### DIFF
--- a/lib/edgehog_device_forwarder_web/controllers/error_controller.ex
+++ b/lib/edgehog_device_forwarder_web/controllers/error_controller.ex
@@ -1,0 +1,34 @@
+# Copyright 2024 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule EdgehogDeviceForwarderWeb.ErrorController do
+  @moduledoc """
+  Default fallback controller for common errors.
+  """
+
+  use EdgehogDeviceForwarderWeb, :controller
+
+  def call(conn, {:error, :token_not_found}) do
+    error = dgettext("errors", "Session not found or device not connected")
+
+    conn
+    |> send_resp(404, error)
+    |> halt()
+  end
+
+  def call(conn, {:error, :request_timeout}) do
+    error = dgettext("errors", "Request timeout")
+
+    conn
+    |> send_resp(408, error)
+    |> halt()
+  end
+
+  def call(conn, {:error, :invalid_request_port}) do
+    error = dgettext("errors", "The specified request port is not a valid port")
+
+    conn
+    |> send_resp(400, error)
+    |> halt()
+  end
+end

--- a/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
+++ b/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
@@ -11,6 +11,8 @@ defmodule EdgehogDeviceForwarderWeb.UserController do
   alias EdgehogDeviceForwarder.Forwarder
   alias EdgehogDeviceForwarderProto.Edgehog.Device.Forwarder.Http, as: HTTP
 
+  action_fallback EdgehogDeviceForwarderWeb.ErrorController
+
   @doc """
   Redirect the request to the appropriate device session.
   """

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -1,6 +1,21 @@
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
 
 msgid ""
 msgstr ""
 "Language: en\n"
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:5
+#, elixir-autogen, elixir-format
+msgid "Session not found or device not connected"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:13
+#, elixir-autogen, elixir-format
+msgid "Request timeout"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:21
+#, elixir-autogen, elixir-format
+msgid "The specified request port is not a valid port"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -1,2 +1,20 @@
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
+
+msgid ""
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:5
+#, elixir-autogen, elixir-format
+msgid "Session not found or device not connected"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:13
+#, elixir-autogen, elixir-format
+msgid "Request timeout"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:21
+#, elixir-autogen, elixir-format
+msgid "The specified request port is not a valid port"
+msgstr ""

--- a/test/edgehog_device_forwarder_web/controllers/user_controller_test.exs
+++ b/test/edgehog_device_forwarder_web/controllers/user_controller_test.exs
@@ -34,6 +34,45 @@ defmodule EdgehogDeviceForwarderWeb.UserControllerTest do
         get(conn, path, request.body)
       end
     end
+
+    test "returns 404 when no device is connected with the given token", %{
+      conn: conn,
+      http_request: request
+    } do
+      not_connected_token = "not_connected_token"
+      path = "/v1/#{not_connected_token}/http/80"
+
+      conn
+      |> add_request_headers(request.headers)
+      |> get(path, request.body)
+      |> response(404)
+    end
+
+    test "returns 400 with an invalid request port", %{
+      conn: conn,
+      http_request: request,
+      ping_pong_token: token
+    } do
+      path = "/v1/#{token}/http/not_a_port"
+
+      conn
+      |> add_request_headers(request.headers)
+      |> get(path, request.body)
+      |> response(400)
+    end
+
+    test "returns 408 if it reaches timeout", %{
+      conn: conn,
+      http_request: request,
+      timeout_token: token
+    } do
+      path = "/v1/#{token}/http/80"
+
+      conn
+      |> add_request_headers(request.headers)
+      |> get(path, request.body)
+      |> response(408)
+    end
   end
 
   def add_header({header, value}, conn), do: Plug.Conn.put_req_header(conn, header, value)

--- a/test/support/forwarder_case.ex
+++ b/test/support/forwarder_case.ex
@@ -15,7 +15,7 @@ defmodule EdgehogDeviceForwarder.ForwarderCase do
     me = self()
     ping_pong_socket = spawn(fn -> ping_pong(me) end)
 
-    [ping_pong_token: register_device(ping_pong_socket)]
+    [ping_pong_token: register_device(ping_pong_socket), timeout_token: register_device(me)]
   end
 
   def ping_pong(target, response_function \\ &make_response/1) do


### PR DESCRIPTION
handle errors returned by Forwarder.http_to_device instead of crashing
the controller.

returns simple strings and a reasonable code.