### PR TITLE
 feat(nix): initial package 

### DIFF
--- a/.nix/hash
+++ b/.nix/hash
@@ -1,0 +1,1 @@
+sha256-KtB/dOwXQoBKmuRTLDMkDZ7D6gwraBuhG6teDNVtDrs=

--- a/.nix/hash
+++ b/.nix/hash
@@ -1,1 +1,1 @@
-sha256-KtB/dOwXQoBKmuRTLDMkDZ7D6gwraBuhG6teDNVtDrs=
+sha256-pekItDuSOEltzuXWmCTKGBmQDvMMbDRqU4AiXEKJ3lA=

--- a/.nix/hash.license
+++ b/.nix/hash.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 SECO Mind Srl
+SPDX-License-Identifier: CC0-1.0

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,7 @@ import Config
 
 config :edgehog_device_forwarder, EdgehogDeviceForwarderWeb.Endpoint,
   url: [host: "localhost"],
+  server: true,
   render_errors: [
     formats: [json: EdgehogDeviceForwarderWeb.ErrorJSON],
     layout: false

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,6 @@ import Config
 
 config :edgehog_device_forwarder, EdgehogDeviceForwarderWeb.Endpoint,
   url: [host: "localhost"],
-  server: true,
   render_errors: [
     formats: [json: EdgehogDeviceForwarderWeb.ErrorJSON],
     layout: false

--- a/flake.lock
+++ b/flake.lock
@@ -15,17 +15,16 @@
       },
       "locked": {
         "dir": "backend",
-        "lastModified": 1694686647,
-        "narHash": "sha256-oRe2NsZzJiKrk6ah8O+3Ks4ZzqtFpF+cb9PYuVYVeW8=",
-        "owner": "noaccOS",
+        "lastModified": 1696606996,
+        "narHash": "sha256-4l50jTbsARQzIk8DCSUsLpimI+1HThW16zhDAVAub3k=",
+        "owner": "edgehog-device-manager",
         "repo": "edgehog",
-        "rev": "c40a60e1837ccf5eb6609e209fe6bf5dee52255c",
+        "rev": "b13fa6a119a43a9f344d5c39aa8e9e3eedfbae46",
         "type": "github"
       },
       "original": {
         "dir": "backend",
-        "owner": "noaccOS",
-        "ref": "nix",
+        "owner": "edgehog-device-manager",
         "repo": "edgehog",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -15,15 +15,31 @@
       },
       "locked": {
         "dir": "backend",
-        "lastModified": 1696606996,
-        "narHash": "sha256-4l50jTbsARQzIk8DCSUsLpimI+1HThW16zhDAVAub3k=",
+        "lastModified": 1701429914,
+        "narHash": "sha256-d2POTdLSAPnBK8UnmHDmVMym95TqJoruojA6Vb/6r0g=",
         "owner": "edgehog-device-manager",
         "repo": "edgehog",
-        "rev": "b13fa6a119a43a9f344d5c39aa8e9e3eedfbae46",
+        "rev": "9700b43bdea5218c690a0ca8bdf27254b6157729",
         "type": "github"
       },
       "original": {
         "dir": "backend",
+        "owner": "edgehog-device-manager",
+        "repo": "edgehog",
+        "type": "github"
+      }
+    },
+    "edgehog-base": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701429914,
+        "narHash": "sha256-d2POTdLSAPnBK8UnmHDmVMym95TqJoruojA6Vb/6r0g=",
+        "owner": "edgehog-device-manager",
+        "repo": "edgehog",
+        "rev": "9700b43bdea5218c690a0ca8bdf27254b6157729",
+        "type": "github"
+      },
+      "original": {
         "owner": "edgehog-device-manager",
         "repo": "edgehog",
         "type": "github"
@@ -37,11 +53,30 @@
         ]
       },
       "locked": {
-        "lastModified": 1690384244,
-        "narHash": "sha256-R0S3mVW50WZwmaNSbaL6AvGjxtR+4l7OXoTRHr23pw0=",
+        "lastModified": 1696521035,
+        "narHash": "sha256-IW9AyjOc48mxXMR3xZzDNWPZRnUfU4eW1H6MyHyYZmQ=",
         "owner": "noaccOS",
         "repo": "elixir-utils",
-        "rev": "0a9dccc959427d8b95625f247e9ba0c5bebe9f75",
+        "rev": "7babc3e6072fb14463b6aa97c24cb5b57bb4517a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noaccOS",
+        "repo": "elixir-utils",
+        "type": "github"
+      }
+    },
+    "elixir-utils_2": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1701687340,
+        "narHash": "sha256-1Hp570xQmiVu96luHnmO0x27o55o2qQFDqgYwXEyggQ=",
+        "owner": "noaccOS",
+        "repo": "elixir-utils",
+        "rev": "af322a3a4d918b82aaec75d4ce7f5af0a45a74aa",
         "type": "github"
       },
       "original": {
@@ -53,11 +88,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -71,11 +106,29 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -86,11 +139,26 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694593561,
-        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "lastModified": 1691683125,
+        "narHash": "sha256-FMU62G57HDbJwU+9V3q7I0mBaQYTYQdtPNlJt2t5/A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1697b7d480449b01111e352021f46e5879e47643",
+        "rev": "4d2389b927696ef8da4ef76b03f2d306faf87929",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {
@@ -102,12 +170,29 @@
     "root": {
       "inputs": {
         "edgehog": "edgehog",
+        "edgehog-base": "edgehog-base",
+        "elixir-utils": "elixir-utils_2",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       flake = false;
     };
     edgehog = {
-      url = "github:noaccOS/edgehog/nix?dir=backend";
+      url = "github:edgehog-device-manager/edgehog?dir=backend";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
if you want to start this program in production environment,
first set the`SECRET_KEY_BASE` environment variable,
then use `nix run .# start --impure` to run it locally.

to start the program in dev environment, use `nix run .#dev start`

the only shortcoming is that the dependencies hash needs to be updated
manually.
It is possible to setup the CI to create a pull request with the
updated hash when `nix flake check` fails.