### PR TITLE
feat(monitor): synchronous callback add 

### DIFF
--- a/lib/edgehog_device_forwarder/termination_callbacks/worker.ex
+++ b/lib/edgehog_device_forwarder/termination_callbacks/worker.ex
@@ -8,7 +8,7 @@ defmodule EdgehogDeviceForwarder.TerminationCallbacks.Worker do
 
   @spec add(pid, (-> any)) :: :ok
   def add(pid, on_close) when is_pid(pid) and is_function(on_close, 0) do
-    GenServer.cast(__MODULE__, {:add, pid, on_close})
+    :ok = GenServer.call(__MODULE__, {:add, pid, on_close})
   end
 
   @spec start_link(any) :: GenServer.on_start()
@@ -31,12 +31,12 @@ defmodule EdgehogDeviceForwarder.TerminationCallbacks.Worker do
   end
 
   @impl GenServer
-  def handle_cast({:add, pid, on_close}, state)
+  def handle_call({:add, pid, on_close}, _from, state)
       when is_pid(pid) and is_function(on_close, 0) do
     Process.monitor(pid)
     ConCache.put(@cache_id, pid, on_close)
 
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
   @impl GenServer

--- a/test/edgehog_device_forwarder/termination_callbacks_test.exs
+++ b/test/edgehog_device_forwarder/termination_callbacks_test.exs
@@ -32,12 +32,6 @@ defmodule EdgehogDeviceForwarder.TerminationCallbacksTest do
 
     TerminationCallbacks.add(process, send_message_to_self)
 
-    # get_state always runs synchronously after `add` finishes.
-    #   we use this to make sure the callback has been inserted in the cache
-    #   before killing the process
-    GenServer.whereis(Worker)
-    |> :sys.get_state()
-
     Supervisor.terminate_child(TerminationCallbacks, Worker)
     Supervisor.restart_child(TerminationCallbacks, Worker)
 


### PR DESCRIPTION
use a call instead of a cast, to make sure the message has been received
from the server, as cast would return :ok even when the server is down

Depends on #19 and includes its commits