### PR TITLE
chore: fix copyright

### DIFF
--- a/lib/edgehog_device_forwarder/http_requests/core.ex
+++ b/lib/edgehog_device_forwarder/http_requests/core.ex
@@ -1,3 +1,6 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule EdgehogDeviceForwarder.HTTPRequests.Core do
   @moduledoc """
   Implementation of the core functions for `EdgehogDeviceForwarder.HTTPRequests`.

--- a/lib/edgehog_device_forwarder/http_requests/errors.ex
+++ b/lib/edgehog_device_forwarder/http_requests/errors.ex
@@ -1,3 +1,6 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule EdgehogDeviceForwarder.HTTPRequests.Errors do
   @moduledoc """
   Error handling for `EdgehogDeviceForwarder.HTTPRequests`

--- a/lib/edgehog_device_forwarder/websockets/core.ex
+++ b/lib/edgehog_device_forwarder/websockets/core.ex
@@ -1,3 +1,6 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule EdgehogDeviceForwarder.WebSockets.Core do
   @moduledoc """
   Implementation of the core functions for `EdgehogDeviceForwarder.WebSockets`.

--- a/lib/edgehog_device_forwarder/websockets/errors.ex
+++ b/lib/edgehog_device_forwarder/websockets/errors.ex
@@ -1,3 +1,6 @@
+# Copyright 2023 SECO Mind Srl
+# SPDX-License-Identifier: Apache-2.0
+
 defmodule EdgehogDeviceForwarder.WebSockets.Errors do
   @moduledoc """
   Error handling for `EdgehogDeviceForwarder.WebSockets`


### PR DESCRIPTION
some files did not contain the copyright and license identifier.
fixes reuse lint.