### PR TITLE
fix: ttyd support for chromium

### DIFF
--- a/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
+++ b/lib/edgehog_device_forwarder_web/controllers/user_controller.ex
@@ -32,8 +32,9 @@ defmodule EdgehogDeviceForwarderWeb.UserController do
           |> send_resp(response.status_code, response.body)
           |> halt()
 
-        {{:upgrade, :websocket}, _response, socket_data} ->
+        {{:upgrade, :websocket}, response, socket_data} ->
           conn
+          |> merge_resp_headers(response.headers)
           |> WebSockAdapter.upgrade(EdgehogDeviceForwarderWeb.UserSocket, socket_data, [])
           |> halt()
 


### PR DESCRIPTION
Chromium panics when the response headers
don't include the "sec-websocket-protocol" from the request, and cowboy does not set this header by default.

As the device's response includes this header, we can just merge its headers before upgrading the connection.