### PR TITLE
feat(user_controller)!: strict protocol check

### DIFF
--- a/lib/edgehog_device_forwarder_web/controllers/error_controller.ex
+++ b/lib/edgehog_device_forwarder_web/controllers/error_controller.ex
@@ -31,4 +31,13 @@ defmodule EdgehogDeviceForwarderWeb.ErrorController do
     |> send_resp(400, error)
     |> halt()
   end
+
+  def call(conn, {:error, {:invalid_protocol, protocol}}) do
+    error = dgettext("errors", "Request protocol not yet handled")
+    error = ~s[#{error}: "#{protocol}"]
+
+    conn
+    |> send_resp(501, error)
+    |> halt()
+  end
 end

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -1,21 +1,25 @@
 # Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
-
 msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:5
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:12
 #, elixir-autogen, elixir-format
 msgid "Session not found or device not connected"
 msgstr ""
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:13
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:20
 #, elixir-autogen, elixir-format
 msgid "Request timeout"
 msgstr ""
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:21
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "The specified request port is not a valid port"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:36
+#, elixir-autogen, elixir-format
+msgid "Request protocol not yet handled"
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -1,20 +1,24 @@
 # Copyright 2023-2024 SECO Mind Srl
 # SPDX-License-Identifier: CC0-1.0
-
 msgid ""
 msgstr ""
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:5
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:12
 #, elixir-autogen, elixir-format
 msgid "Session not found or device not connected"
 msgstr ""
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:13
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:20
 #, elixir-autogen, elixir-format
 msgid "Request timeout"
 msgstr ""
 
-#: lib/edgehog_device_forwarder_web/controllers/fallback_controller.ex:21
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:28
 #, elixir-autogen, elixir-format
 msgid "The specified request port is not a valid port"
+msgstr ""
+
+#: lib/edgehog_device_forwarder_web/controllers/error_controller.ex:36
+#, elixir-autogen, elixir-format
+msgid "Request protocol not yet handled"
 msgstr ""


### PR DESCRIPTION
previously the protocol was not checked at all and the controller just defaulted to using http.

now if the request specify an unsupported protocol, an error 501 is returned.