### PR TITLE
Set a default timeout of 1 minute for the device socket timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,7 @@ config :edgehog_device_forwarder, EdgehogDeviceForwarderWeb.Endpoint,
   ],
   pubsub_server: EdgehogDeviceForwarder.PubSub,
   live_view: [signing_salt: "KhdMSuxy"],
-  device_socket_timeout: :timer.hours(2)
+  device_socket_timeout: :timer.minutes(1)
 
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,6 @@ import Config
 
 config :edgehog_device_forwarder, EdgehogDeviceForwarderWeb.Endpoint,
   http: [ip: {0, 0, 0, 0}, port: 4000],
-  device_socket_timeout: :timer.minutes(1),
   check_origin: false,
   code_reloader: true,
   debug_errors: true,


### PR DESCRIPTION
The default timeout for closing WebSocket connections of devices is different between the development and production environment.

The PR sets a uniform, sensible timeout for all environments: using 1 minute also for the production environment instead of the previous timeout of 2 hours.
